### PR TITLE
Correctly manage the `withoutKeycloak=false` case

### DIFF
--- a/dev-scripts/build_fabric8.sh
+++ b/dev-scripts/build_fabric8.sh
@@ -38,7 +38,7 @@ else
     additionalArgument="-DwithoutKeycloak -DlocalCheRepository=${UPSTREAM_CHE_PATH}"
 fi
 
-bash cico_build.sh $* $additionalArgument
+bash cico_build.sh $additionalArgument $* 
 if [ $? -ne 0 ]; then
   echo 'Build Failed!'
   cd ${currentDir}


### PR DESCRIPTION
In fact the `withoutKeycloak` was not correctly managed in the build script.
After fixing this, the workspace can start with Keycloak enabled.

Signed-off-by: David Festal <dfestal@redhat.com>